### PR TITLE
Comment specified prefix-space as the desired behavior but prefix-t p…

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,8 +1,8 @@
 # Prefix (Ctrl+Space)
 
 unbind C-b
-set-option -g prefix C-t
-bind C-t send-prefix
+set-option -g prefix C-Space
+bind C-Space send-prefix
 
 # Vi Mode
 


### PR DESCRIPTION
…resent. Remapped to `Ctrl+Space` for one to use the spacebar.